### PR TITLE
Complete install for non-release config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ target_link_libraries(wdt wdtlib_min)
 
 ### Install rules
 
-install(TARGETS wdt wdtlib wdtlib_min folly4wdt CONFIGURATIONS Release
+install(TARGETS wdt wdtlib wdtlib_min folly4wdt
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib


### PR DESCRIPTION
This fixes incomplete installs when the build configuration is not "Release". (This affects package managers that use an alternate build configuration to apply system-defaults.)