### PR TITLE
make wcp.sh works on OSX

### DIFF
--- a/test/wcp.sh
+++ b/test/wcp.sh
@@ -53,7 +53,11 @@ if [ -z "$REMOTEDIR" ] ; then
 fi
 
 FILENAME=`basename $SRCPATH`
-SIZE=`stat -L -c %s $SRCPATH`
+if [ 'Darwin' = `uname -s` ] ; then
+    SIZE=`stat -L -f %z $SRCPATH`
+else
+    SIZE=`stat -L -c %s $SRCPATH`
+fi
 if [ $? -ne 0 ] ; then
   echo "Error stating $SRCPATH. aborting."
   exit 1


### PR DESCRIPTION
fix `stat: illegal option -- c`  error on OSX