### PR TITLE
Fix compilation problems with modern versions of Folly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 # The part of folly that isn't pure .h and we use:
 set (FOLLY_CPP_SRC
 "${FOLLY_SOURCE_DIR}/folly/Conv.cpp"
+"${FOLLY_SOURCE_DIR}/folly/lang/CString.cpp"
 "${FOLLY_SOURCE_DIR}/folly/Demangle.cpp"
 "${FOLLY_SOURCE_DIR}/folly/hash/Checksum.cpp"
 "${FOLLY_SOURCE_DIR}/folly/hash/detail/ChecksumDetail.cpp"


### PR DESCRIPTION
Attempting to compile WDT against modern versions of Folly results in the following error when linking `wdtbin` (aliased to `wdt`).

```shell
libfolly4wdt.so: undefined reference to `folly::strlcpy(char*, char const*, unsigned long)'
```

It seems that the source files that define `folly::strlcpy`, namely `lang/CString.cpp` need to be included explicitly.

It also appears that this problem has already been addressed by [a fork of WDT](https://github.com/fran6co/wdt/commit/02f07aa31314148e66b4e7951144ac982cbdabd5).