### PR TITLE
Add missing include for std::find

### DIFF
--- a/test/EncryptionTest.cpp
+++ b/test/EncryptionTest.cpp
@@ -3,6 +3,8 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <algorithm> // for std::find
+
 namespace facebook {
 namespace wdt {
 


### PR DESCRIPTION
Without this, the compilation fails with :
wdt/test/EncryptionTest.cpp:76:57: error: no matching function for call to 'find(std::vector<std::__cxx11::basic_string<char> >::iterator, std::vector<std::__cxx11::basic_string<char> >::iterator, std::string&)'

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>