### PR TITLE
Fix building via cmake

### DIFF
--- a/Throttler.cpp
+++ b/Throttler.cpp
@@ -74,7 +74,7 @@ void Throttler::setThrottlerRates(double& avgRatePerSec,
   // configureOptions will change the rates in case they don't make
   // sense
   configureOptions(avgRatePerSec, bucketRatePerSec, tokenBucketLimit);
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
 
   resetState();
 
@@ -144,7 +144,7 @@ void Throttler::sleep(double sleepTimeSecs) const {
 
 double Throttler::calculateSleep(double deltaProgress,
                                  const Clock::time_point& now) {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   if (refCount_ <= 0) {
     WLOG(ERROR) << "Using the throttler without registering the transfer";
     return -1;
@@ -186,7 +186,7 @@ void Throttler::printPeriodicLogs(const Clock::time_point& now,
    * made periodically.
    */
   std::chrono::duration<double> elapsedLogDuration;
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   instantProgress_ += deltaProgress;
   elapsedLogDuration = now - lastLogTime_;
   double elapsedLogSeconds = elapsedLogDuration.count();
@@ -227,7 +227,7 @@ double Throttler::averageThrottler(const Clock::time_point& now) {
 }
 
 void Throttler::startTransfer() {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   if (refCount_ == 0) {
     resetState();
   }
@@ -244,38 +244,38 @@ void Throttler::resetState() {
 }
 
 void Throttler::endTransfer() {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   WDT_CHECK(refCount_ > 0);
   refCount_--;
 }
 
 double Throttler::getProgress() {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   return progress_;
 }
 
 double Throttler::getAvgRatePerSec() {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   return avgRatePerSec_;
 }
 
 double Throttler::getPeakRatePerSec() {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   return bucketRatePerSec_;
 }
 
 double Throttler::getBucketLimit() {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   return tokenBucketLimit_;
 }
 
 int64_t Throttler::getThrottlerLogTimeMillis() {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   return throttlerLogTimeMillis_;
 }
 
 void Throttler::setThrottlerLogTimeMillis(int64_t throttlerLogTimeMillis) {
-  std::unique_lock lock(throttlerMutex_);
+  std::unique_lock<folly::SpinLock> lock(throttlerMutex_);
   throttlerLogTimeMillis_ = throttlerLogTimeMillis;
 }
 

--- a/util/FileCreator.cpp
+++ b/util/FileCreator.cpp
@@ -95,7 +95,7 @@ int FileCreator::openForFirstBlock(ThreadCtx &threadCtx,
                                    BlockDetails const *blockDetails) {
   int fd = openAndSetSize(threadCtx, blockDetails);
   {
-    std::unique_lock guard(lock_);
+    std::unique_lock<folly::SpinLock> guard(lock_);
     auto it = fileStatusMap_.find(blockDetails->seqId);
     WDT_CHECK(it != fileStatusMap_.end());
     it->second = fd >= 0 ? ALLOCATED : FAILED;
@@ -110,7 +110,7 @@ bool FileCreator::waitForAllocationFinish(int allocatingThreadIndex,
   std::unique_lock<std::mutex> waitLock(allocationMutex_);
   while (true) {
     {
-      std::unique_lock guard(lock_);
+      std::unique_lock<folly::SpinLock> guard(lock_);
       auto it = fileStatusMap_.find(seqId);
       WDT_CHECK(it != fileStatusMap_.end());
       if (it->second == ALLOCATED) {

--- a/util/FileCreator.h
+++ b/util/FileCreator.h
@@ -78,7 +78,7 @@ class FileCreator {
 
   /// clears allocation status map, called after end of each session
   void clearAllocationMap() {
-    std::unique_lock guard(lock_);
+    std::unique_lock<folly::SpinLock> guard(lock_);
     fileStatusMap_.clear();
   }
 


### PR DESCRIPTION
Commit fdbc543223 adds code that relies on C++17-only class template
argument deduction to wdt. However, `CMakeLists.txt` specifies the C++
standard used by the project as `set(CMAKE_CXX_STANDARD 14)`. As
a result, the project can no longer be built by following the steps from
the project's documentation because the compilation fails with an error:

    [ 36%] Building CXX object CMakeFiles/wdt_min.dir/util/FileCreator.cpp.o
    In file included from wdt/util/FileCreator.cpp:9:0:
    wdt/util/FileCreator.h: In member function ‘void facebook::wdt::FileCreator::clearAllocationMap()’:
    wdt/util/FileCreator.h:81:22: error: missing template arguments before ‘guard’
         std::unique_lock guard(lock_);
                          ^~~~~
    wdt/util/FileCreator.cpp: In member function ‘int facebook::wdt::FileCreator::openForFirstBlock(facebook::wdt::ThreadCtx&, const facebook::wdt::BlockDetails*)’:
    wdt/util/FileCreator.cpp:98:22: error: missing template arguments before ‘guard’
         std::unique_lock guard(lock_);
                          ^~~~~
    wdt/util/FileCreator.cpp: In member function ‘bool facebook::wdt::FileCreator::waitForAllocationFinish(int, int64_t)’:
    wdt/util/FileCreator.cpp:113:24: error: missing template arguments before ‘guard’
           std::unique_lock guard(lock_);
                            ^~~~~
    CMakeFiles/wdt_min.dir/build.make:206: recipe for target 'CMakeFiles/wdt_min.dir/util/FileCreator.cpp.o' failed
    make[2]: *** [CMakeFiles/wdt_min.dir/util/FileCreator.cpp.o] Error 1
    CMakeFiles/Makefile2:105: recipe for target 'CMakeFiles/wdt_min.dir/all' failed
    make[1]: *** [CMakeFiles/wdt_min.dir/all] Error 2

We fix the issue by providing explicit template argument for
`std::unique_lock` where fdbc543223 replaced `folly::SpinLockGuard` with
bare `std::unique_lock`.