### PR TITLE
Fix building via cmake - alternative approach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ project("WDT" LANGUAGES C CXX VERSION 1.32.1910230)
 # WDT itself works fine with C++11 (gcc 4.8 for instance) but more recent folly
 # started to require C++14, so you can either get an older snapshot of folly
 # and set "11" below or use this:
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # somehow 'option' for this doesn't seeem to work/I don't know how to make it


### PR DESCRIPTION
Alternative approach to changes proposed in [pull #216](https://github.com/facebook/wdt/pull/216) to issues introduced by commit [fdbc543](https://github.com/facebook/wdt/commit/fdbc5432230290f86ff8ad89ab52d5b7fef232b4) - simply update the C++ standard used from 14 to 17.