### PR TITLE
Fix build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ if (NOT WDT_USE_SYSTEM_FOLLY)
   "${FOLLY_SOURCE_DIR}/folly/Conv.cpp"
   "${FOLLY_SOURCE_DIR}/folly/Demangle.cpp"
   "${FOLLY_SOURCE_DIR}/folly/lang/CString.cpp"
+  "${FOLLY_SOURCE_DIR}/folly/lang/ToAscii.cpp"
   "${FOLLY_SOURCE_DIR}/folly/hash/Checksum.cpp"
   "${FOLLY_SOURCE_DIR}/folly/hash/detail/ChecksumDetail.cpp"
   "${FOLLY_SOURCE_DIR}/folly/hash/detail/Crc32cDetail.cpp"

--- a/Sender.h
+++ b/Sender.h
@@ -11,8 +11,6 @@
 #include <iostream>
 #include <memory>
 
-#include <gtest/gtest_prod.h>
-
 #include <wdt/WdtBase.h>
 #include <wdt/util/ClientSocket.h>
 


### PR DESCRIPTION
These are two one-line fixes for ensuring that `wdt` builds properly with a recent folly and for when `gtest` is not installed on the system.