### PR TITLE
fix build issue: `libfolly4wdt.so: undefined reference to...`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,12 +71,16 @@ if (NOT WDT_USE_SYSTEM_FOLLY)
   "${FOLLY_SOURCE_DIR}/folly/Demangle.cpp"
   "${FOLLY_SOURCE_DIR}/folly/lang/CString.cpp"
   "${FOLLY_SOURCE_DIR}/folly/lang/ToAscii.cpp"
+  "${FOLLY_SOURCE_DIR}/folly/lang/SafeAssert.cpp"
+  "${FOLLY_SOURCE_DIR}/folly/lang/Exception.cpp"
   "${FOLLY_SOURCE_DIR}/folly/hash/Checksum.cpp"
   "${FOLLY_SOURCE_DIR}/folly/hash/detail/ChecksumDetail.cpp"
   "${FOLLY_SOURCE_DIR}/folly/hash/detail/Crc32cDetail.cpp"
   "${FOLLY_SOURCE_DIR}/folly/hash/detail/Crc32CombineDetail.cpp"
   "${FOLLY_SOURCE_DIR}/folly/ScopeGuard.cpp"
   "${FOLLY_SOURCE_DIR}/folly/detail/SplitStringSimd.cpp"
+  "${FOLLY_SOURCE_DIR}/folly/detail/TrapOnAvx512.cpp"
+  "${FOLLY_SOURCE_DIR}/folly/external/fast-crc32/sse_crc32c_v8s3x3.cpp"
   )
 endif()
 


### PR DESCRIPTION
Fix issue for `undefined references` while building - while running `make -j`
```
  /usr/bin/ld: libfolly4wdt.so: undefined reference to `folly::detail::hasTrapOnAvx512()'
  /usr/bin/ld: libfolly4wdt.so: undefined reference to `void folly::detail::safe_assert_terminate<false>(folly::detail::safe_assert_arg const*, ...)'
  /usr/bin/ld: libfolly4wdt.so: undefined reference to `folly::current_exception()'
  /usr/bin/ld: libfolly4wdt.so: undefined reference to `folly::detail::sse_crc32c_v8s3x3(unsigned char const*, unsigned long, unsigned int)'
```